### PR TITLE
Support multiple AjaxSubmitButtons with useWithActiveForm

### DIFF
--- a/AjaxSubmitButton.php
+++ b/AjaxSubmitButton.php
@@ -147,7 +147,7 @@ class AjaxSubmitButton extends Widget
         $this->ajaxOptions= Json::encode($this->ajaxOptions);
 
 $js = <<<SEL
-        $(document).unbind('beforeSubmit').on('beforeSubmit', "#{$this->useWithActiveForm}", function () {
+        $(document).unbind('beforeSubmit.{$this->useWithActiveForm}').on('beforeSubmit.{$this->useWithActiveForm}', "#{$this->useWithActiveForm}", function () {
             if ($(this).find('.has-error').length < 1) {
                 $.ajax({$this->ajaxOptions});
             }


### PR DESCRIPTION
When having multiple AjaxSubmitButtons on one page. that all use an activeform, only one will work. The last one will unbind all previous beforeSubmit functions. This pull requests fixes this, by using a namespace on the beforeSubmit event, so only events on the specific form will be unbound.